### PR TITLE
CICD-28 | replace npm i for npm install

### DIFF
--- a/.github/workflows/format_code.yaml
+++ b/.github/workflows/format_code.yaml
@@ -29,7 +29,7 @@ jobs:
               cache-dependency-path: frontend/package-lock.json
 
          - name: Install dependencies
-           run: npm ci
+           run: npm install
 
          - name: Run format command
            run: npm run format


### PR DESCRIPTION
this way, tha package.json and package-lock.json are in sync